### PR TITLE
Use name generator to generate city names.

### DIFF
--- a/binaries/data/core/data/names/name_gen_test.hjson
+++ b/binaries/data/core/data/names/name_gen_test.hjson
@@ -1,4 +1,4 @@
-{
+[{
   name: tester
   rules: {
       1: "{s1}{s2}"
@@ -13,4 +13,4 @@
     ash
     burn
   ]
-}
+}]

--- a/binaries/data/core/data/names/town_names.hjson
+++ b/binaries/data/core/data/names/town_names.hjson
@@ -1,5 +1,5 @@
 [{
-  name: tester
+  name: Town Names
   rules: {
       1: "{s1}{s2}"
   }

--- a/binaries/data/core/data/names/town_names.hjson
+++ b/binaries/data/core/data/names/town_names.hjson
@@ -1,4 +1,4 @@
-{
+[{
   name: tester
   rules: {
       1: "{s1}{s2}"
@@ -75,4 +75,4 @@
     town
     wick
   ]
-}
+}]

--- a/binaries/data/core/scripts/universegen/defaultgen.lua
+++ b/binaries/data/core/scripts/universegen/defaultgen.lua
@@ -132,7 +132,7 @@ generators:insert({
         -- TODO(EhWhoAmI): Create more complex economy, with cities specializing in stuff
         -- TODO(EhWhoAmI): Make slider for configuring the amount of cities and stuff
         local city_count = 1
-        for index = 1, city_count, 1 do
+        for _ = 1, city_count, 1 do
             local city = add_planet_settlement(planet, random(-90, 90), random(-180, 180))
             -- Get random city name
             set_name(city, get_random_name("Town Names", "1"))

--- a/binaries/data/core/scripts/universegen/defaultgen.lua
+++ b/binaries/data/core/scripts/universegen/defaultgen.lua
@@ -134,7 +134,8 @@ generators:insert({
         local city_count = 1
         for index = 1, city_count, 1 do
             local city = add_planet_settlement(planet, random(-90, 90), random(-180, 180))
-            set_name(city, "City ".. index)
+            -- Get random city name
+            set_name(city, get_random_name("Town Names", "1"))
             local pop_unit = add_population_segment(city, random_normal_int(50000000, 2000000)) -- 100 million
             add_cash(pop_unit, 1000) -- 1 billion
             attach_market(market, pop_unit)

--- a/src/client/scenes/universeloadingscene.cpp
+++ b/src/client/scenes/universeloadingscene.cpp
@@ -25,6 +25,7 @@
 #include "common/systems/sysuniversegenerator.h"
 #include "common/scripting/luafunctions.h"
 #include "common/systems/loading/loadgoods.h"
+#include "common/systems/loading/loadnames.h"
 
 cqsp::scene::UniverseLoadingScene::UniverseLoadingScene(cqsp::engine::Application& app) : Scene(app) {}
 
@@ -83,7 +84,7 @@ void cqsp::scene::UniverseLoadingScene::LoadUniverse() {
 
     LoadResource(GetApp(), "goods", cqsp::common::systems::loading::LoadGoods);
     LoadResource(GetApp(), "recipes", cqsp::common::systems::loading::LoadRecipes);
-
+    LoadResource(GetApp(), "names", cqsp::common::systems::loading::LoadNameLists);
     // Initialize planet terrains
     cqsp::asset::HjsonAsset* asset = GetAssetManager().GetAsset<cqsp::asset::HjsonAsset>("core:terrain_colors");
     cqsp::common::systems::loading::LoadTerrainData(GetApp().GetUniverse(), asset->data);

--- a/src/common/scripting/luafunctions.cpp
+++ b/src/common/scripting/luafunctions.cpp
@@ -297,6 +297,10 @@ void FunctionUser(cqsp::engine::Application& app) {
     REGISTER_FUNCTION("get_name", [&](entt::entity entity) {
         return universe.get<cqspc::Name>(entity).name;
     });
+
+    REGISTER_FUNCTION("get_random_name", [&](const std::string& name_gen, const std::string &rule) {
+        return universe.name_generators[name_gen].Generate(rule);
+    });
 }
 
 void FunctionPopulation(cqsp::engine::Application& app) {

--- a/src/common/systems/loading/loadnames.cpp
+++ b/src/common/systems/loading/loadnames.cpp
@@ -1,0 +1,31 @@
+/* Conquer Space
+* Copyright (C) 2021 Conquer Space
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include "common/systems/loading/loadnames.h"
+
+#include "common/systems/names/namegenerator.h"
+
+void cqsp::common::systems::loading::LoadNameLists(cqsp::common::Universe &universe,
+                                                   Hjson::Value &value) {
+    for (int i = 0; i < value.size(); i++) {
+        Hjson::Value &name_list = value[i];
+        cqsp::common::systems::names::NameGenerator name_gen;
+        name_gen.SetRandom(universe.random.get());
+
+        name_gen.LoadNameGenerator(name_list);
+        universe.name_generators[name_gen.GetName()] = name_gen;
+    }
+}

--- a/src/common/systems/loading/loadnames.h
+++ b/src/common/systems/loading/loadnames.h
@@ -1,0 +1,25 @@
+/* Conquer Space
+* Copyright (C) 2021 Conquer Space
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <hjson.h>
+
+#include "common/universe.h"
+
+namespace cqsp::common::systems::loading {
+void LoadNameLists(cqsp::common::Universe&, Hjson::Value&);
+}

--- a/src/common/systems/loading/loadnames.h
+++ b/src/common/systems/loading/loadnames.h
@@ -22,4 +22,4 @@
 
 namespace cqsp::common::systems::loading {
 void LoadNameLists(cqsp::common::Universe&, Hjson::Value&);
-}
+}  // namespace cqsp::common::systems::loading

--- a/src/common/systems/names/namegenerator.h
+++ b/src/common/systems/names/namegenerator.h
@@ -59,6 +59,8 @@ class NameGenerator {
     void SetRandom(util::IRandom* rand) {
         random = rand;
     }
+
+    const std::string& GetName() { return name; }
  private:
     std::map<std::string, std::vector<std::string>> syllables_list;
     std::map<std::string, std::string> rule_list;

--- a/src/common/universe.h
+++ b/src/common/universe.h
@@ -24,6 +24,7 @@
 
 #include "common/stardate.h"
 #include "common/util/random/random.h"
+#include "common/systems/names/namegenerator.h"
 
 namespace cqsp {
 namespace common {
@@ -35,6 +36,7 @@ class Universe : public entt::registry {
     std::map<std::string, entt::entity> goods;
     std::map<std::string, entt::entity> recipes;
     std::map<std::string, entt::entity> terrain_data;
+    std::map<std::string, systems::names::NameGenerator> name_generators;
 
     void EnableTick() { to_tick = true; }
     void DisableTick() { to_tick = false; }

--- a/src/engine/asset/assetmanager.cpp
+++ b/src/engine/asset/assetmanager.cpp
@@ -316,6 +316,7 @@ std::unique_ptr<cqsp::asset::Package> cqsp::asset::AssetLoader::LoadPackage(std:
     // So the folders we have to keep track off are the goods and recipes
     HjsonPrototypeDirectory(*package, fmt::format("{}/data/goods", mount_point), "goods");
     HjsonPrototypeDirectory(*package, fmt::format("{}/data/recipes", mount_point), "recipes");
+    HjsonPrototypeDirectory(*package, fmt::format("{}/data/names", mount_point), "names");
 
     SPDLOG_INFO("Loaded prototype directories");
 

--- a/test/common/systems/name/namegenerator_test.cpp
+++ b/test/common/systems/name/namegenerator_test.cpp
@@ -31,7 +31,7 @@ TEST(NameGeneratorTest, BasicTest) {
     cqsp::common::util::StdRandom std_random(31415926535);
     Hjson::Value val;
     val = Hjson::UnmarshalFromFile("../data/core/data/names/name_gen_test.hjson");
-    gen.LoadNameGenerator(val);
+    gen.LoadNameGenerator(val[0]);
     gen.SetRandom(&std_random);
 
     std::vector<std::string> potential_names{"Aelash", "Ashash", "Aelburn", "Ashburn"};
@@ -58,7 +58,7 @@ TEST(NameGeneratorTest, IncorrectFormatTest) {
     cqsp::common::util::StdRandom std_random(31415926535);
     Hjson::Value val;
     val = Hjson::UnmarshalFromFile("../data/core/data/names/name_gen_test.hjson");
-    gen.LoadNameGenerator(val);
+    gen.LoadNameGenerator(val[0]);
     gen.SetRandom(&std_random);
 
     std::vector<std::string> potential_names{"Aelash", "Ashash", "Aelburn", "Ashburn"};


### PR DESCRIPTION
Planet names are not done yet, because a scheme for planet names has not been written yet. This is just a proof of concept to show that the name generator works.

To generate a name in the script, call the function `get_random_name(<name list>, <rule name>)`, which returns a name generated by the game.