### PR TITLE
Add if the window is decorated or not in client options

### DIFF
--- a/src/engine/application.cpp
+++ b/src/engine/application.cpp
@@ -290,10 +290,13 @@ class GLWindow : public cqsp::engine::Window {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        glfwWindowHint(GLFW_SAMPLES, 4);
+        glfwWindowHint(GLFW_SAMPLES, app->GetClientOptions()
+                .GetOptions()["samples"].to_int64());
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, true);
         glfwWindowHint(GLFW_DOUBLEBUFFER, true);
-        glfwWindowHint(GLFW_DECORATED, false);
+        glfwWindowHint(GLFW_DECORATED,
+            ((bool)app->GetClientOptions()
+                .GetOptions()["window"]["decorated"]) ? GLFW_TRUE : GLFW_FALSE);
 
 #ifdef __APPLE__
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
@@ -574,6 +577,10 @@ int Application::destroy() {
     glfwDestroyWindow(window(m_window));
     glfwTerminate();
     ENGINE_LOG_INFO("Killed GLFW");
+
+    // Save options
+    m_client_options.WriteOptions();
+    ENGINE_LOG_INFO("Saved Options");
 
     ENGINE_LOG_INFO("Good bye");
     spdlog::shutdown();

--- a/src/engine/clientoptions.cpp
+++ b/src/engine/clientoptions.cpp
@@ -42,11 +42,13 @@ Hjson::Value cqsp::client::ClientOptions::GetDefaultOptions() {
     Hjson::Value default_options;
     default_options["window"]["width"] = 1280;
     default_options["window"]["height"] = 720;
+    default_options["window"]["decorated"] = true;
     default_options["full_screen"] = false;
     default_options["icon"] = "icon.png";
     default_options["audio"]["music"] = 1.0f;
     default_options["audio"]["ui"] = 0.80f;
     default_options["splashscreens"] = "../data/core/gui/splashscreens";
+    default_options["samples"] = 4;
     return default_options;
 }
 


### PR DESCRIPTION
This can be changed in the config file.

Config file is also now written after the app closes.